### PR TITLE
Add wait_device_ops() to ltc_engine.py

### DIFF
--- a/engines/ltc_engine.py
+++ b/engines/ltc_engine.py
@@ -43,6 +43,7 @@ def train_loop(args, model, optim_func, input_func, grad_func=None) :
                     torch.cuda.profiler.start()
                     start_evt.record()
     
+    ltm.wait_device_ops()
     stop_evt.record()
     stop_evt.synchronize()
     return start_evt.elapsed_time(stop_evt)


### PR DESCRIPTION
wait_device_ops() before cuda event/sync is important to ensure the background thread that is executing the traced LTC graph has finished and therefore all the cuda kernels have been scheduled.

This also seems to fix a hang that was happening on exit, which I'm looking into further.